### PR TITLE
Fixed light radius when harvesting

### DIFF
--- a/scripts/Ally.cs
+++ b/scripts/Ally.cs
@@ -54,12 +54,12 @@ public partial class Ally : CharacterBody2D
         float distanceLength = distance.Length();  // Berechne die Länge des Vektors
 
         // If ally further away than big circle, he is in the darkness
-        if (distanceLength > _core.LightRadiusBiggerCircle)
+        if (distanceLength > Core.LightRadiusBiggerCircle)
         {
             CurrentState = AllyState.Darkness;
         }
         //if ally not in darkness and closer than the small Light Radius, he is in small circle
-        else if (distanceLength < _core.LightRadiusSmallerCircle)
+        else if (distanceLength < Core.LightRadiusSmallerCircle)
         {
             CurrentState = AllyState.SmallCircle;
         }
@@ -203,8 +203,8 @@ public partial class Ally : CharacterBody2D
                 {
                     continue;
                 }
-                _core.MaterialCount += item.Amount;
-                _core.IncreaseScale();
+                Core.MaterialCount += item.Amount;
+                Core.IncreaseScale();
                 GD.Print("Increased scale");
             }
             SInventory.Clear();

--- a/scripts/CombatAlly.cs
+++ b/scripts/CombatAlly.cs
@@ -51,12 +51,12 @@ public partial class CombatAlly : CharacterBody2D
         float distanceLength = distance.Length(); // Get the length of the vector
 
         // If ally further away than big circle, he is in the darkness
-        if (distanceLength > _core.LightRadiusBiggerCircle)
+        if (distanceLength > Core.LightRadiusBiggerCircle)
         {
             CurrentState = AllyState.Darkness;
         }
         // If ally not in darkness and closer than the small Light Radius, he is in small circle
-        else if (distanceLength < _core.LightRadiusSmallerCircle)
+        else if (distanceLength < Core.LightRadiusSmallerCircle)
         {
             CurrentState = AllyState.SmallCircle;
         }

--- a/scripts/Core.cs
+++ b/scripts/Core.cs
@@ -7,12 +7,11 @@ namespace Game.Scripts;
 public partial class Core : Node2D
 {
 
-    public const int PIXELSCALE = 1000;
-    public int MaterialCount;
+    public const int PIXELSCALE = 600;
+    public static int MaterialCount;
     private static PointLight2D? s_coreLight;
-    public const int Pixelscale = 1000;
-    [Export] public float LightRadiusSmallerCircle { get; private set; } = 1000;
-    [Export] public float LightRadiusBiggerCircle { get; private set; } = 1500;
+    public static float LightRadiusSmallerCircle { get; private set; }
+    public static float LightRadiusBiggerCircle { get; private set; }
     public Inventory? Inventory;
 
     public override void _Ready()
@@ -25,6 +24,8 @@ public partial class Core : Node2D
         this.Scale = s_coreLight.Scale;
         this.Position = s_coreLight.Position;
         MaterialCount = 0;
+        LightRadiusSmallerCircle = s_coreLight.Scale.X * PIXELSCALE;
+        LightRadiusBiggerCircle = s_coreLight.Scale.X * PIXELSCALE * 1.5f;
     }
 
     private void SetCorePosition(Vector2 position)
@@ -36,8 +37,8 @@ public partial class Core : Node2D
     private void DrawLightRadius()
     {
         Vector2 center = this.Position;
-        DrawArc(center, LightRadiusSmallerCircle, 0, Mathf.Tau, 64, Colors.Red, 4f);
-        DrawArc(center, LightRadiusBiggerCircle, 0, Mathf.Tau, 64, Colors.Blue, 4f);
+        DrawArc(center, Core.LightRadiusSmallerCircle, 0, Mathf.Tau, 64, Colors.Red, 4f);
+        DrawArc(center, Core.LightRadiusBiggerCircle, 0, Mathf.Tau, 64, Colors.Blue, 4f);
         // GD.Print("Drawing circle...");
     }
 
@@ -46,8 +47,11 @@ public partial class Core : Node2D
         DrawLightRadius();
     }
 
-    public void IncreaseScale()
+    public static void IncreaseScale()
     {
         s_coreLight!.Scale *= 1.1f;
+        LightRadiusSmallerCircle *= 1.1f;
+        LightRadiusBiggerCircle *= 1.1f;
     }
+
 }

--- a/scripts/Map.cs
+++ b/scripts/Map.cs
@@ -134,6 +134,7 @@ public partial class Map : Node2D
         _timeElapsed += delta;
         DarknessDamage();
         _Draw();
+        _core.QueueRedraw();
     }
 
     public void AddItem(Itemstack item, int x, int y)

--- a/scripts/Player.cs
+++ b/scripts/Player.cs
@@ -122,12 +122,12 @@ public partial class Player : CharacterBody2D
         float distanceLength = distance.Length();  // Berechne die Länge des Vektors
 
         // If ally further away than big circle, he is in the darkness
-        if (distanceLength > _core.LightRadiusBiggerCircle)
+        if (distanceLength > Core.LightRadiusBiggerCircle)
         {
             CurrentState = AllyState.Darkness;
         }
         //if ally not in darkness and closer than the small Light Radius, he is in small circle
-        else if (distanceLength < _core.LightRadiusSmallerCircle)
+        else if (distanceLength < Core.LightRadiusSmallerCircle)
         {
             CurrentState = AllyState.SmallCircle;
         }


### PR DESCRIPTION
Both circles (blue and red) get bigger when the ally harvests something
![4j](https://github.com/user-attachments/assets/deb2e980-480a-413c-a892-b31f7310b2cb)
