### PR TITLE
Queues for Ally and GeminiService + added semaphore, SendSystemMessage function in Chat

### DIFF
--- a/scenes/levels/ExampleScene.tscn
+++ b/scenes/levels/ExampleScene.tscn
@@ -1281,9 +1281,6 @@ z_index = 150
 position = Vector2(-1429, -221)
 scale = Vector2(0.2, 0.2)
 texture = ExtResource("20_lgqcj")
-script = ExtResource("6_7bcmx")
-NameForAi = "Notebook"
-DescribtionForAi = "there is a Spaceport at (-1950, 2000). This Notebook contains details on how to loot metals from there."
 
 [node name="Interactable" type="Node2D" parent="Notebook"]
 script = ExtResource("7_ji1nn")
@@ -1295,6 +1292,11 @@ script = ExtResource("8_vh33k")
 script = ExtResource("21_2au4o")
 ItemToAddName = "Notebook"
 Amount = 1
+
+[node name="VisibleForAI" type="Node2D" parent="Notebook"]
+script = ExtResource("6_7bcmx")
+NameForAi = "Notebook"
+DescribtionForAi = "there is a Spaceport at (-1950, 2000). This Notebook contains details on how to loot metals from there."
 
 [node name="Signs" type="Node" parent="."]
 

--- a/scenes/levels/ExampleScene.tscn
+++ b/scenes/levels/ExampleScene.tscn
@@ -989,10 +989,11 @@ _darknessCircleDamage = 1
 _allyHealthChangeIntervall = 5.0
 
 [node name="Ally" parent="." node_paths=PackedStringArray("_responseField", "_nameLabel", "Chat") instance=ExtResource("6_l8h37")]
-position = Vector2(870, 83)
+position = Vector2(483, 1011)
 _responseField = NodePath("ResponseField")
 _nameLabel = NodePath("Label")
-_visionRadius = 200
+_visionRadius = 150
+_interactionRadius = 100
 Chat = NodePath("Ally1Cam/Ally1Chat")
 
 [node name="Ally1Cam" type="Camera2D" parent="Ally"]
@@ -1060,6 +1061,7 @@ fit_content = true
 metadata/_edit_use_anchors_ = true
 
 [node name="Ally2" parent="." node_paths=PackedStringArray("_responseField", "_nameLabel", "Chat") groups=["navigation"] instance=ExtResource("6_l8h37")]
+position = Vector2(5956, -4450)
 _responseField = NodePath("ResponseField")
 _nameLabel = NodePath("Label")
 _visionRadius = 200
@@ -1110,10 +1112,10 @@ metadata/_edit_use_anchors_ = true
 
 [node name="ResponseField" type="RichTextLabel" parent="Ally2"]
 modulate = Color(0.6, 0.6, 0.6, 0.654902)
-offset_left = 1384.0
-offset_top = 454.0
-offset_right = 1984.0
-offset_bottom = 754.0
+offset_left = 997.0
+offset_top = 1382.0
+offset_right = 1597.0
+offset_bottom = 1682.0
 theme_override_colors/table_border = Color(0, 0, 0, 1)
 theme_override_colors/table_even_row_bg = Color(0, 0, 0, 1)
 theme_override_colors/table_odd_row_bg = Color(0, 0, 0, 1)
@@ -1162,7 +1164,7 @@ color = Color(0.20871, 0.20871, 0.20871, 1)
 metadata/_edit_use_anchors_ = true
 
 [node name="CanvasModulate" type="CanvasModulate" parent="ColorRect"]
-color = Color(0.227451, 0.227451, 0.227451, 1)
+color = Color(0.332881, 0.332881, 0.332881, 1)
 
 [node name="Obstacles" type="Node" parent="."]
 
@@ -1317,6 +1319,7 @@ NameForAi = "Rune Holder"
 DescribtionForAi = "There is a Code needed"
 
 [node name="EnemyManager" type="Node2D" parent="."]
+position = Vector2(5956, -4450)
 script = ExtResource("1_bmkfv")
 EnemyScene = ExtResource("10_tv6x7")
 _minSpawnInterval = 5.0
@@ -1345,8 +1348,10 @@ metadata/_edit_lock_ = true
 [node name="Mouse" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
+offset_left = 5956.0
+offset_top = -4450.0
+offset_right = 5996.0
+offset_bottom = -4410.0
 metadata/_edit_use_anchors_ = true
 
 [node name="MouseLabel" type="RichTextLabel" parent="Mouse"]
@@ -1365,7 +1370,7 @@ scale = Vector2(10, 10)
 tile_set = ExtResource("23_6wlm7")
 
 [node name="Abandoned Village" type="TileMapLayer" parent="Abandoned Village/Tileset Layers"]
-position = Vector2(2595, 2509)
+position = Vector2(8551, -1941)
 scale = Vector2(4, 4)
 tile_set = ExtResource("24_igx6k")
 
@@ -1393,6 +1398,13 @@ Radius = 500
 position = Vector2(-8.99999, -122.001)
 scale = Vector2(2.75, 5)
 
+[node name="AiNode" parent="Abandoned Village/HauntedForestVillage" instance=ExtResource("13_05imv")]
+NameForAi = "Haunted Forest Village"
+DescriptionForAi = "Looks Spooky. Make comments about the architecture of the houses."
+IsAddItemOnInteract = false
+IsRemovable = false
+IsInteractable = false
+
 [node name="Spaceport" type="Node" parent="."]
 
 [node name="Tilemap Layers" type="Node" parent="Spaceport"]
@@ -1413,30 +1425,39 @@ DescribtionForAi = "Spaceport at (-3050, 2000)"
 [node name="AiNode" parent="Spaceport" instance=ExtResource("13_05imv")]
 position = Vector2(-3046, 1587)
 scale = Vector2(0.2, 0.2)
+NameForAi = "Engine exhaust"
+DescriptionForAi = "with a manual you could loot some copper."
 
-[node name="Flashlight" type="Node2D" parent="."]
-position = Vector2(5630, -5543)
-script = ExtResource("6_7bcmx")
-NameForAi = "Flashlight"
-DescribtionForAi = "It might be useful in the Haunted Forest Village"
+[node name="TorchOld" type="Node2D" parent="."]
+position = Vector2(5538, -6212)
 
-[node name="ItemAdder" type="Node2D" parent="Flashlight"]
+[node name="ItemAdder" type="Node2D" parent="TorchOld"]
 script = ExtResource("21_2au4o")
 ItemToAddName = "Torch"
 Amount = 1
 
-[node name="Interactable" type="Node2D" parent="Flashlight"]
+[node name="Interactable" type="Node2D" parent="TorchOld"]
 position = Vector2(-1, 0)
 script = ExtResource("7_ji1nn")
 
-[node name="VisibleForAI" type="Node2D" parent="Flashlight"]
-position = Vector2(0, 7)
+[node name="VisibleForAI" type="Node2D" parent="TorchOld"]
+position = Vector2(13284, -7783)
 script = ExtResource("6_7bcmx")
 NameForAi = "Torch"
 DescribtionForAi = "It's not lighted yet. Ask the commander if he wants to pick it up. (COMMAND: INTERACT). Ask the commander how he intends to light this torch."
 
-[node name="AudioManager" type="Node" parent="."]
+[node name="Torch" parent="." instance=ExtResource("13_05imv")]
+position = Vector2(5631, -5569)
+NameForAi = "Torch"
+DescriptionForAi = "It's not lighted yet. Ask the commander if he wants to pick it up. (COMMAND: INTERACT) and inquire how the commander how he intends to light this torch."
+FromChosenMaterial = 7
+IsRemovable = false
+
+[node name="AudioManager" type="Node" parent="." node_paths=PackedStringArray("_menuMusic", "_gameMusic", "_gameOverMusic")]
 script = ExtResource("25_fif0r")
+_menuMusic = NodePath("intro_music")
+_gameMusic = NodePath("game_music")
+_gameOverMusic = NodePath("game_over")
 
 [node name="creepy_music" type="AudioStreamPlayer" parent="AudioManager"]
 stream = ExtResource("26_rqvqj")
@@ -1459,10 +1480,10 @@ anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 1529.0
-offset_top = 270.0
-offset_right = 1633.0
-offset_bottom = 301.0
+offset_left = 1142.0
+offset_top = 1198.0
+offset_right = 1246.0
+offset_bottom = 1229.0
 grow_horizontal = 2
 grow_vertical = 0
 script = ExtResource("30_pwpih")
@@ -1509,5 +1530,5 @@ button_group = ExtResource("31_rop2t")
 text = "Ally 1"
 
 [node name="IntroScene" parent="." node_paths=PackedStringArray("_ally") instance=ExtResource("32_bdur0")]
-visible = false
 _ally = NodePath("../Ally")
+_enableIntroScene = false

--- a/scenes/levels/ExampleScene.tscn
+++ b/scenes/levels/ExampleScene.tscn
@@ -993,7 +993,6 @@ position = Vector2(483, 1011)
 _responseField = NodePath("ResponseField")
 _nameLabel = NodePath("Label")
 _visionRadius = 150
-_interactionRadius = 100
 Chat = NodePath("Ally1Cam/Ally1Chat")
 
 [node name="Ally1Cam" type="Camera2D" parent="Ally"]
@@ -1401,11 +1400,6 @@ position = Vector2(-8.99999, -122.001)
 scale = Vector2(2.75, 5)
 
 [node name="AiNode" parent="Abandoned Village/HauntedForestVillage" instance=ExtResource("13_05imv")]
-NameForAi = "Haunted Forest Village"
-DescriptionForAi = "Looks Spooky. Make comments about the architecture of the houses."
-IsAddItemOnInteract = false
-IsRemovable = false
-IsInteractable = false
 
 [node name="Spaceport" type="Node" parent="."]
 
@@ -1427,8 +1421,6 @@ DescribtionForAi = "Spaceport at (-3050, 2000)"
 [node name="AiNode" parent="Spaceport" instance=ExtResource("13_05imv")]
 position = Vector2(-3046, 1587)
 scale = Vector2(0.2, 0.2)
-NameForAi = "Engine exhaust"
-DescriptionForAi = "with a manual you could loot some copper."
 
 [node name="TorchOld" type="Node2D" parent="."]
 position = Vector2(5538, -6212)
@@ -1450,10 +1442,6 @@ DescribtionForAi = "It's not lighted yet. Ask the commander if he wants to pick 
 
 [node name="Torch" parent="." instance=ExtResource("13_05imv")]
 position = Vector2(5631, -5569)
-NameForAi = "Torch"
-DescriptionForAi = "It's not lighted yet. Ask the commander if he wants to pick it up. (COMMAND: INTERACT) and inquire how the commander how he intends to light this torch."
-FromChosenMaterial = 7
-IsRemovable = false
 
 [node name="AudioManager" type="Node" parent="." node_paths=PackedStringArray("_menuMusic", "_gameMusic", "_gameOverMusic")]
 script = ExtResource("25_fif0r")
@@ -1534,3 +1522,10 @@ text = "Ally 1"
 [node name="IntroScene" parent="." node_paths=PackedStringArray("_ally") instance=ExtResource("32_bdur0")]
 _ally = NodePath("../Ally")
 _enableIntroScene = false
+
+[node name="AiNode" parent="." instance=ExtResource("13_05imv")]
+position = Vector2(3715, -1345)
+ObjectName = "Box"
+ObjectDescription = "What might possibly be in there?"
+ItemAdderMessage = PackedStringArray("You picked up: ", "It could possibly be useful for increasing the core light radius.")
+AddedMaterial = 1

--- a/scenes/levels/ExampleScene.tscn
+++ b/scenes/levels/ExampleScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=55 format=4 uid="uid://dfkwq6qwtxw25"]
+[gd_scene load_steps=54 format=4 uid="uid://dfkwq6qwtxw25"]
 
 [ext_resource type="Script" path="res://scripts/EnemyManager.cs" id="1_bmkfv"]
 [ext_resource type="Script" path="res://scripts/Map.cs" id="1_pa1ge"]
@@ -8,7 +8,6 @@
 [ext_resource type="PackedScene" uid="uid://6gwtt7kwq2p" path="res://scenes/prefabs/Ally.tscn" id="6_l8h37"]
 [ext_resource type="Script" path="res://scripts/Interaction/Interactable.cs" id="7_ji1nn"]
 [ext_resource type="PackedScene" uid="uid://csb6x207vu85x" path="res://scenes/prefabs/copper_tree.tscn" id="7_njspg"]
-[ext_resource type="Script" path="res://scripts/Interaction/Removeable.cs" id="8_vh33k"]
 [ext_resource type="PackedScene" uid="uid://ki7e88gvvcs" path="res://scenes/prefabs/ice_tree.tscn" id="9_tf77n"]
 [ext_resource type="PackedScene" uid="uid://bgxxp0o5kdpkq" path="res://scenes/prefabs/Enemy.tscn" id="10_tv6x7"]
 [ext_resource type="Script" path="res://scripts/Core.cs" id="11_wagl7"]
@@ -1026,6 +1025,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="VisibleForAI" type="Node2D" parent="Ally"]
 script = ExtResource("6_7bcmx")
+NameForAi = "James"
+DescribtionForAi = "The ally james"
 
 [node name="Label" type="Label" parent="Ally"]
 offset_left = -21.0
@@ -1275,28 +1276,6 @@ position = Vector2(5.5, 26)
 scale = Vector2(10, 10)
 shape = SubResource("RectangleShape2D_xdi6d")
 
-[node name="Notebook" type="Sprite2D" parent="."]
-z_index = 150
-position = Vector2(-1429, -221)
-scale = Vector2(0.2, 0.2)
-texture = ExtResource("20_lgqcj")
-
-[node name="Interactable" type="Node2D" parent="Notebook"]
-script = ExtResource("7_ji1nn")
-
-[node name="Removeable" type="Node" parent="Notebook"]
-script = ExtResource("8_vh33k")
-
-[node name="ItemAdder" type="Node2D" parent="Notebook"]
-script = ExtResource("21_2au4o")
-ItemToAddName = "Notebook"
-Amount = 1
-
-[node name="VisibleForAI" type="Node2D" parent="Notebook"]
-script = ExtResource("6_7bcmx")
-NameForAi = "Notebook"
-DescribtionForAi = "there is a Spaceport at (-1950, 2000). This Notebook contains details on how to loot metals from there."
-
 [node name="Signs" type="Node" parent="."]
 
 [node name="Grave Runeholder" type="Marker2D" parent="Signs"]
@@ -1441,7 +1420,10 @@ NameForAi = "Torch"
 DescribtionForAi = "It's not lighted yet. Ask the commander if he wants to pick it up. (COMMAND: INTERACT). Ask the commander how he intends to light this torch."
 
 [node name="Torch" parent="." instance=ExtResource("13_05imv")]
-position = Vector2(5631, -5569)
+position = Vector2(1978, -1250)
+ObjectName = "old drawer"
+ObjectDescription = "there might be something in there"
+AddedMaterial = 7
 
 [node name="AudioManager" type="Node" parent="." node_paths=PackedStringArray("_menuMusic", "_gameMusic", "_gameOverMusic")]
 script = ExtResource("25_fif0r")
@@ -1520,6 +1502,7 @@ button_group = ExtResource("31_rop2t")
 text = "Ally 1"
 
 [node name="IntroScene" parent="." node_paths=PackedStringArray("_ally") instance=ExtResource("32_bdur0")]
+visible = false
 _ally = NodePath("../Ally")
 _enableIntroScene = false
 
@@ -1529,3 +1512,17 @@ ObjectName = "Box"
 ObjectDescription = "What might possibly be in there?"
 ItemAdderMessage = PackedStringArray("You picked up: ", "It could possibly be useful for increasing the core light radius.")
 AddedMaterial = 1
+
+[node name="NotebookNode" parent="." instance=ExtResource("13_05imv")]
+position = Vector2(-1441, -220)
+ObjectName = "Notebook"
+ObjectDescription = "there is a Spaceport at (-1950, 2000)."
+ObjectHint = "Tell the commander about the object you just spotted. You may use the command [GOTO AND INTERACT] on this object if the commander explicitly told you to engage with it. If he didn't, propose but don't instantly do it yourself that you may interact with it, but don't use the word interact. Use the appropriate term or verb for: "
+ItemAdderMessage = PackedStringArray("You picked up: ", "It could possibly be useful for the space port. This Notebook contains details on how to loot metals from there.")
+AddedMaterial = 9
+
+[node name="Notebook" type="Sprite2D" parent="NotebookNode"]
+z_index = 150
+position = Vector2(7, -5.99998)
+scale = Vector2(0.2, 0.2)
+texture = ExtResource("20_lgqcj")

--- a/scenes/levels/HauntedForest/insideBigHouse.tscn
+++ b/scenes/levels/HauntedForest/insideBigHouse.tscn
@@ -21,9 +21,6 @@ tile_set = ExtResource("1_wk18s")
 
 [node name="ChairLeft" type="Node2D" parent="InsideBigHouse"]
 position = Vector2(-135, -49)
-script = ExtResource("2_nypkc")
-NameForAi = "Chair"
-DescribtionForAi = "Looks comfy"
 
 [node name="DrawerLeft" type="Node2D" parent="InsideBigHouse"]
 position = Vector2(-133, -67)
@@ -40,7 +37,6 @@ script = ExtResource("3_hysjd")
 SceneToShow = ExtResource("4_5v46h")
 Radius = 99999
 NeedsToBeInInventoryName = 7
-ItemActivationStatus = false
 
 [node name="Chest" parent="InsideBigHouse/Sprite2D/ChestInsideHouse" instance=ExtResource("4_5v46h")]
 

--- a/scenes/prefabs/Ally.tscn
+++ b/scenes/prefabs/Ally.tscn
@@ -92,6 +92,8 @@ _data = {
 z_index = 50
 script = ExtResource("1_anjrv")
 PathFindingMovement = NodePath("PathFindingMovement")
+_visionRadius = 600
+_interactionRadius = 100
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
 path_max_distance = 20.0
@@ -115,7 +117,8 @@ shape = SubResource("CapsuleShape2D_rn1pq")
 
 [node name="PathFindingMovement" type="Node" parent="." node_paths=PackedStringArray("_character", "_agent", "_sprite")]
 script = ExtResource("4_v650j")
-_minTargetDistance = 150
+_minTargetDistance = 30
+_targetDistanceVariation = 30
 _character = NodePath("..")
 _agent = NodePath("../NavigationAgent2D")
 _sprite = NodePath("../Sprite2D")

--- a/scripts/AI/AiNode.cs
+++ b/scripts/AI/AiNode.cs
@@ -23,6 +23,8 @@ public partial class AiNode : Node2D
     [Export] public bool IsRemovable = true;
 
     [Export] public bool IsInteractable = true;
+    [Export] public bool IsSendSystemMessage = false;
+    [Export] public string? SystemMessageInstructionForAlly = "";
 
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()

--- a/scripts/AI/AiNode.cs
+++ b/scripts/AI/AiNode.cs
@@ -42,11 +42,13 @@ public partial class AiNode : Node2D
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {
+        GD.Print("trying to get nodes");
         VisibleForAI visibleForAi = GetNode<VisibleForAI>("VisibleForAI");
         Game.Scripts.Interaction.ItemAdder adder = GetNode<Game.Scripts.Interaction.ItemAdder>("ItemAdder");
         ShowWhileInRadius showWhileInRadius = GetNode<ShowWhileInRadius>("ShowWhileInRadius");
         Removeable removable = GetNode<Removeable>("Removeable");
         Interactable interactable = GetNode<Interactable>("Interactable");
+        GD.Print("got all nodes");
 
         if (IsActive)
         {
@@ -56,15 +58,16 @@ public partial class AiNode : Node2D
             if (Interactable)
             {
                 visibleForAi.DescribtionForAi += " [HINT] " + ObjectHint + "[" + visibleForAi.NameForAi + "] [HINT END].";
-
                 if (!string.IsNullOrEmpty(CustomOverrideMessage)) // voreingestellte System message
                 {
+                    GD.Print("custom override message");
                     interactable.SystemMessageForAlly = CustomOverrideMessage
                         + EndMessage
                         + "\n";
                 }
                 else if (AddedMaterial != Game.Scripts.Items.Material.None) // sonst wenn item geadded wird, zusammengesetzte SystemMessage
                 {
+                    GD.Print("added material system message");
                     adder.Amount = Amount;
                     adder.ItemToAdd = AddedMaterial;
 
@@ -78,6 +81,7 @@ public partial class AiNode : Node2D
                 }
                 else
                 {
+                    GD.Print("default system message");
                     interactable.SystemMessageForAlly = DefaultMessage
                                                                    + "\n";
                     adder.QueueFree();

--- a/scripts/AI/AiNode.cs
+++ b/scripts/AI/AiNode.cs
@@ -1,30 +1,43 @@
 using System;
 
 using Game.Scripts.AI;
+using Game.Scripts.Interaction;
 
 using Godot;
 
 using Material = Game.Scripts.Items.Material;
 public partial class AiNode : Node2D
 {
-    [Export] public bool IsVisibleForAi = true;
-    [Export] public string NameForAi = "";
-    [Export] public string DescriptionForAi = "";
+    [ExportGroup("Object Name and Description for AI")]
+    public bool IsActive = true;
+    [Export] public string ObjectName = "";
+    [Export] public string ObjectDescription = "";
 
-    [Export] public bool IsAddItemOnInteract = true;
-    [Export] public Material FromChosenMaterial;
+    [Export]
+    public string ObjectHint = "Tell the commander about the object you just spotted. " +
+                                  "You may use the command [GOTO AND INTERACT] on this object if the commander explicitly told you to engage with it." +
+                                  "If he didn't, propose that you may interact with it, but don't use the word interact. " +
+                                  "Use the appropriate term or verb for: ";
+
+    [ExportGroup("Interaction")]
+    [Export(PropertyHint.None, "Can be interacted with?")] public bool Interactable = true;
+    [Export(PropertyHint.None, "is removed after interacting?")] public bool RemovedAfter = true;
+
+    [ExportGroup("System Message after interaction")]
+    [Export] public string? CustomOverrideMessage;
+    [Export] public string?[] ItemAdderMessage = ["You picked up: ", "It could possibly be useful for ..."];
+    [Export] public string? DefaultMessage = "Unfortunately, that didn't do anything.";
+    [Export] public string EndMessage = "What do you want the commander to know about that?";
+
+    [ExportGroup("Item Adder")]
+    [Export] public Material AddedMaterial;
     [Export] public int Amount = 1;
 
-    [Export] public bool IsShowWhileInRadius;
-    [Export] public PackedScene ShowWhileInRadiusScene = null!;
+    [ExportGroup("Show scene while in radius (and has item)")]
+    [Export] public bool ShowWhileInRadius;
+    [Export] public PackedScene? SceneToShow;
     [Export] public int Radius = 100;
-    [Export] public Material NeedsToBeInInventory;
-
-    [Export] public bool IsRemovable = true;
-
-    [Export] public bool IsInteractable = true;
-    [Export] public bool IsSendSystemMessage = false;
-    [Export] public string? SystemMessageInstructionForAlly = "";
+    [Export] public Material RequiredMaterial;
 
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
@@ -35,50 +48,78 @@ public partial class AiNode : Node2D
         Removeable removable = GetNode<Removeable>("Removeable");
         Interactable interactable = GetNode<Interactable>("Interactable");
 
-        if (IsVisibleForAi)
+        if (IsActive)
         {
-            visibleForAi.NameForAi = NameForAi;
-            visibleForAi.DescribtionForAi = DescriptionForAi;
+            visibleForAi.NameForAi = ObjectName;
+            visibleForAi.DescribtionForAi = ObjectDescription;
+
+            if (Interactable)
+            {
+                visibleForAi.DescribtionForAi += " [HINT] " + ObjectHint + "[" + visibleForAi.NameForAi + "] [HINT END].";
+
+                if (!string.IsNullOrEmpty(CustomOverrideMessage)) // voreingestellte System message
+                {
+                    interactable.SystemMessageForAlly = CustomOverrideMessage
+                        + EndMessage
+                        + "\n";
+                }
+                else if (AddedMaterial != Game.Scripts.Items.Material.None) // sonst wenn item geadded wird, zusammengesetzte SystemMessage
+                {
+                    adder.Amount = Amount;
+                    adder.ItemToAdd = AddedMaterial;
+
+                    string composedMessage = ItemAdderMessage + " " + Amount + " " + AddedMaterial
+                                                                   + ((Amount > 1) ? "s " : " ")
+                                                                   + (RemovedAfter ? "Now, it's no longer available. " : " ")
+                                                                   + EndMessage
+                                                                   + "\n";
+                    interactable.SystemMessageForAlly = composedMessage;
+                    GD.Print(interactable.SystemMessageForAlly + " ***** item adder default system message *****");
+                }
+                else
+                {
+                    interactable.SystemMessageForAlly = DefaultMessage
+                                                                   + "\n";
+                    adder.QueueFree();
+                }
+                if (!RemovedAfter)
+                {
+                    removable.QueueFree();
+                }
+            }
+            else
+            {
+                interactable.QueueFree();
+            }
         }
         else
         {
             visibleForAi.QueueFree();
+            adder.QueueFree();
         }
 
-        if (!IsInteractable)
-        {
-            interactable.QueueFree();
-        }
 
-        if (!IsRemovable)
-        {
-            removable.QueueFree();
-        }
-
-        if (IsShowWhileInRadius)
+        if (ShowWhileInRadius && SceneToShow != null)
         {
             showWhileInRadius.Radius = Radius;
-            showWhileInRadius.NeedsToBeInInventoryName = NeedsToBeInInventory;
-            showWhileInRadius.SceneToShow = ShowWhileInRadiusScene;
+            showWhileInRadius.NeedsToBeInInventoryName = RequiredMaterial;
+            showWhileInRadius.SceneToShow = SceneToShow;
         }
         else
         {
+            if (ShowWhileInRadius)
+            {
+                GD.Print("showWhileInRadius removed because selected Scene is null.");
+            }
             showWhileInRadius.QueueFree();
-        }
-
-        if (IsAddItemOnInteract)
-        {
-            adder.Amount = Amount;
-            adder.ItemToAdd = FromChosenMaterial;
-        }
-        else
-        {
-            adder.QueueFree();
         }
     }
 
-    // Called every frame. 'delta' is the elapsed time since the previous frame.
     public override void _Process(double delta)
     {
+        if (!IsActive)
+        {
+            GetParent().QueueFree();
+        }
     }
 }

--- a/scripts/AI/VisibleForAI.cs
+++ b/scripts/AI/VisibleForAI.cs
@@ -16,7 +16,7 @@ public partial class VisibleForAI : Node2D
 
     public override string ToString()
     {
-        if (Godot.GodotObject.IsInstanceIdValid(this.GetInstanceId()))
+        if (IsInstanceValid(this))
         {
             return $"{NameForAi} at ({GlobalPosition.X:F0}, {GlobalPosition.Y:F0}): [Description] {DescribtionForAi}";
         }

--- a/scripts/AI/VisibleForAI.cs
+++ b/scripts/AI/VisibleForAI.cs
@@ -14,15 +14,12 @@ public partial class VisibleForAI : Node2D
         AddToGroup(GroupName);
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
         if (IsInstanceValid(this))
         {
             return $"{NameForAi} at ({GlobalPosition.X:F0}, {GlobalPosition.Y:F0}): [Description] {DescribtionForAi}";
         }
-        else
-        {
-            return "";
-        }
+        return null;
     }
 }

--- a/scripts/Ally.cs
+++ b/scripts/Ally.cs
@@ -207,7 +207,7 @@ public partial class Ally : CharacterBody2D
     {
         _responseQueue.Enqueue(response);
         ProcessResponseQueue();
-        GD.Print("got response of length: " + response.Length + ". Waiting for: " + (int)(1000 * 0.009f * response.Length) + " ms.");
+        // GD.Print("got response of length: " + response.Length + ". Waiting for: " + (int)(1000 * 0.009f * response.Length) + " ms.");
         // await Task.Delay((int)(1000*0.01f * response.Length));
     }
 
@@ -216,12 +216,8 @@ public partial class Ally : CharacterBody2D
         while (_responseQueue.Count > 0)
         {
             string response = _responseQueue.Dequeue();
+
             // Processing response here
-            /* if (response.Contains("INTERACT")) 
-             {
-               Interact();
-             }
-             */
             _matches = ExtractRelevantLines(response);
             string? richtext = "";
             foreach ((string op, string content) in _matches!)
@@ -242,7 +238,7 @@ public partial class Ally : CharacterBody2D
                         SetInteractOnArrival(true);
                         Goto(content);
                         break;
-                    case "GOTO":
+                    case "GOTO": // goto (x, y) location
                         GD.Print("DEBUG: GOTO Match");
                         Goto(content);
                         break;
@@ -257,7 +253,7 @@ public partial class Ally : CharacterBody2D
                         _busy = false;
                         break;
                     default:
-                        GD.Print("DEBUG: NO MATCH FOR : " + op);
+                        //GD.Print("DEBUG: NO MATCH FOR : " + op);
                         break;
                 }
             }

--- a/scripts/Chat.cs
+++ b/scripts/Chat.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 using Game.Scripts.AI;
 
+using GenerativeAI.Exceptions;
+
 using Godot;
 namespace Game.Scripts
 {
@@ -126,6 +128,23 @@ namespace Game.Scripts
             {
                 GD.Print(ex.Message);
                 PlaceholderText = EnterApiPlaceholder;
+            }
+        }
+
+        public async void SendSystemMessage(string systemMessage)
+        {
+            try
+            {
+                string? txt = await GeminiService!.MakeQuery("[SYSTEM MESSAGE] " + systemMessage + " [SYSTEM MESSAGE END] \n"); GD.Print(txt); // put it into text box
+                if (txt == null)
+                {
+                    GD.Print("AI response is null.");
+                }
+                GetParent<Camera2D>().GetParent<Ally>().HandleResponse(txt!);
+            }
+            catch (Exception e)
+            {
+                throw new GenerativeAIException("AI query got an error.", "at system_message: " + systemMessage);
             }
         }
 

--- a/scripts/Chat.cs
+++ b/scripts/Chat.cs
@@ -39,7 +39,7 @@ namespace Game.Scripts
             _ally = GetParent().GetParent<Ally>();
             _responseCount = 0;
             TextSubmitted += OnTextSubmitted;
-            AlreadySeen = _ally.AlwaysVisible.ToList();
+            //  AlreadySeen = _ally.AlwaysVisible.ToList();
 
             string systemPromptAbsolutePath = ProjectSettings.GlobalizePath(_systemPromptFile);
             //   string introductionSystemPromptAbsolutePath = ProjectSettings.GlobalizePath(_introductionSystemPromptFile);
@@ -48,19 +48,20 @@ namespace Game.Scripts
                                                                        // _introductionSystemPrompt = File.ReadAllText(introductionSystemPromptAbsolutePath); // Load intro prompt
 
             InitializeGeminiService(SystemPrompt); // Pass system prompt to InitializeGeminiService
-            foreach (Ally ally in GetTree().GetNodesInGroup("Entities").OfType<Ally>())
-            {
-                if (ally.GetName().ToString().Contains('2'))
-                {
-                    _ally2VisibleForAi = ally.GetNode<VisibleForAI>("VisibleForAI");
-                    AlreadySeen.Add(_ally2VisibleForAi);
-                }
-                else
-                {
-                    _ally1VisibleForAi = ally.GetNode<VisibleForAI>("VisibleForAI");
-                    AlreadySeen.Add(_ally1VisibleForAi);
-                }
-            }
+            /* foreach (Ally ally in GetTree().GetNodesInGroup("Entities").OfType<Ally>())
+             {
+                 if (ally.GetName().ToString().Contains('2'))
+                 {
+                     _ally2VisibleForAi = ally.GetNode<VisibleForAI>("VisibleForAI");
+                     AlreadySeen.Add(_ally2VisibleForAi);
+                 }
+                 else
+                 {
+                     _ally1VisibleForAi = ally.GetNode<VisibleForAI>("VisibleForAI");
+                     AlreadySeen.Add(_ally1VisibleForAi);
+                 }
+             }
+             */
         }
 
         public async void SeenItems()

--- a/scripts/Interaction/Interactable.cs
+++ b/scripts/Interaction/Interactable.cs
@@ -1,3 +1,5 @@
+using Game.Scripts;
+
 using Godot;
 
 [GlobalClass]
@@ -7,8 +9,7 @@ public partial class Interactable : Node2D
     [Signal] public delegate void InteractFromNodeEventHandler(Node caller);
     [Signal] public delegate void InteractEventHandler();
 
-    public bool IsSendSystemMessage = false;
-    public string SystemMessageInstructionForAlly = "";
+    public string? SystemMessageForAlly;
 
     public override void _Ready()
     {
@@ -17,9 +18,10 @@ public partial class Interactable : Node2D
 
     public void Trigger(Node caller)
     {
-        if (IsSendSystemMessage && SystemMessageInstructionForAlly != "")
+        if (!string.IsNullOrEmpty(SystemMessageForAlly) && caller.Name.ToString().Contains("Ally"))
         {
-            GD.Print("caller is: " + caller.Name);
+            Ally ally = (caller as Ally)!;
+            ally.Chat.SendSystemMessage(SystemMessageForAlly);
         }
         EmitSignal(SignalName.Interact);
         EmitSignal(SignalName.InteractFromNode, caller);

--- a/scripts/Interaction/Interactable.cs
+++ b/scripts/Interaction/Interactable.cs
@@ -7,6 +7,9 @@ public partial class Interactable : Node2D
     [Signal] public delegate void InteractFromNodeEventHandler(Node caller);
     [Signal] public delegate void InteractEventHandler();
 
+    public bool IsSendSystemMessage = false;
+    public string SystemMessageInstructionForAlly = "";
+
     public override void _Ready()
     {
         AddToGroup(GroupName);
@@ -14,6 +17,10 @@ public partial class Interactable : Node2D
 
     public void Trigger(Node caller)
     {
+        if (IsSendSystemMessage && SystemMessageInstructionForAlly != "")
+        {
+            GD.Print("caller is: " + caller.Name);
+        }
         EmitSignal(SignalName.Interact);
         EmitSignal(SignalName.InteractFromNode, caller);
     }

--- a/scripts/Interaction/Removeable.cs
+++ b/scripts/Interaction/Removeable.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 using Game.Scripts;
 using Game.Scripts.AI;
@@ -20,24 +22,9 @@ public partial class Removeable : Node
             }
         }
     }
-    public void Remove()
+    public async void Remove()
     {
         GD.Print("Removed something");
-        VisibleForAI visibleForAI = GetParent().GetNode<VisibleForAI>("VisibleForAI");
-        Godot.Collections.Array<Node> entityGroup = GetTree().GetNodesInGroup("Entities");
-        Chat? chat = null!;
-        foreach (Ally entity in entityGroup)
-        {
-            if (entity.Name.ToString().Contains('2'))
-            {
-                chat = entity.GetNode<Chat>("Ally2Cam/Ally2Chat");
-            }
-            else
-            {
-                chat = entity.GetNode<Chat>("Ally1Cam/Ally1Chat");
-            }
-            chat.AlreadySeen.Remove(visibleForAI);
-        }
         GetParent().CallDeferred(Node.MethodName.QueueFree);
     }
 }

--- a/scripts/Interaction/ShowWhileInRadius.cs
+++ b/scripts/Interaction/ShowWhileInRadius.cs
@@ -88,36 +88,46 @@ public partial class ShowWhileInRadius : Node2D
                          && (NeedsToBeInInventoryName == Game.Scripts.Items.Material.None || (_nearestAlly.SsInventory.ContainsMaterial(NeedsToBeInInventoryName) && _nearestAlly.Lit)))
                 {
                     show = true;
+                    /*
+                   if (this.GetName() != "Sprite2D")
+                   {
+                       Sprite2D? sprite = GetParent() as Sprite2D;
+                       if (sprite != null)
+                       {
+                           sprite!.Visible = true;
+                       }
+                   }
+                   else
+                   {
+                       GD.Print("this is Sprite2D error");
+                   }
 
-                    if (this.GetName() != "Sprite2D")
-                    {
-                        Sprite2D? sprite = GetParent() as Sprite2D;
-                        if (sprite != null)
-                        {
-                            sprite!.Visible = true;
-                        }
-                    }
-                    else
-                    {
-                        GD.Print("this is Sprite2D error");
-                    }
-
-                    if (this.GetName() == "ChestInsideHouse")
-                    {
-                        SpawnChild();
-                        // has AiNode (Node2D) now
-                        AiNode aiNode = GetNode<AiNode>("AiNode");
-                        aiNode.IsVisibleForAi = true;
-                        aiNode.NameForAi = "Wooden Chest";
-                        aiNode.DescriptionForAi = "Seems to be locked. Maybe there's a key in the city?";
-                        aiNode.IsInteractable = true;
-                        aiNode.IsAddItemOnInteract = true;
-                        aiNode.Amount = 1;
-                        aiNode.FromChosenMaterial = Game.Scripts.Items.Material.FestiveStaff;
-                    }
+                   if (this.GetName() == "ChestInsideHouse")
+                   {
+                       SpawnChild();
+                       // has AiNode (Node2D) now
+                       AiNode aiNode = GetNode<AiNode>("AiNode");
+                       aiNode.IsVisibleForAi = true;
+                       aiNode.NameForAi = "Wooden Chest";
+                       aiNode.DescriptionForAi = "Seems to be locked. Maybe there's a key in the city?";
+                       aiNode.IsInteractable = true;
+                       aiNode.IsAddItemOnInteract = true;
+                       aiNode.Amount = 1;
+                       aiNode.FromChosenMaterial = Game.Scripts.Items.Material.FestiveStaff;
+                   }
+                   */
 
                 }
             }
+        }
+        Sprite2D? sprite = GetParent<Sprite2D>();
+        if (sprite != null)
+        {
+            SetShowSceneState(sprite, show);
+        }
+        else
+        {
+            GD.Print("Sprite2D is null. Can't show chest right now!");
         }
 
 

--- a/scripts/Items/Inventory.cs
+++ b/scripts/Items/Inventory.cs
@@ -52,7 +52,7 @@ public partial class Inventory
         {
             return new Itemstack(Material.None);
         }
-        return Items[i];
+        return Items[i]!;
     }
 
     public bool FitItem(Itemstack stack)
@@ -218,6 +218,6 @@ public partial class Inventory
 
     public Itemstack[] GetItems()
     {
-        return Items;
+        return Items!;
     }
 }

--- a/scripts/Map.cs
+++ b/scripts/Map.cs
@@ -57,7 +57,6 @@ public partial class Map : Node2D
         if (_timeElapsed >= _allyHealthChangeIntervall)
         {
             List<Game.Scripts.Ally> allyGroup = GetTree().GetNodesInGroup("Entities").OfType<Ally>().ToList();
-            List<CombatAlly> combatAllyGroup = GetTree().GetNodesInGroup("Entities").OfType<CombatAlly>().ToList();
 
             foreach (Ally entity in allyGroup)
             {

--- a/scripts/PathFindingMovement.cs
+++ b/scripts/PathFindingMovement.cs
@@ -41,18 +41,7 @@ public partial class PathFindingMovement : Node
     }
     public override void _PhysicsProcess(double delta)
     {
-        if (_agent.TargetPosition.DistanceTo(GetParent<Node2D>().GlobalPosition) < 200)
-        {
-            _reachedTarget = true;
-        }
-        else
-        {
-            _reachedTarget = false;
-        }
         _agent.SetTargetPosition(TargetPosition);
-        //GD.Print(_character.Name);
-        //GD.Print($"Current Agent: {_agent.Name}");
-        //GD.Print($"Target Position: {_agent.TargetPosition}");
 
         if (_debug)
         {
@@ -75,11 +64,21 @@ public partial class PathFindingMovement : Node
             _character.Velocity = newVel;
             _character.MoveAndSlide();
         }
-        else if (!_reachedTarget)
+        else if (!_reachedTarget) // Check if target is reached BEFORE setting _reachedTarget to true
         {
-            _currentTargetDistance = 200;
+            _currentTargetDistance = _minTargetDistance;
             EmitSignal(SignalName.ReachedTarget);
             _reachedTarget = true;
+        }
+
+        // This block should come AFTER the signal emitting logic
+        if (_agent.TargetPosition.DistanceTo(GetParent<Node2D>().GlobalPosition) < _minTargetDistance)
+        {
+            _reachedTarget = true;
+        }
+        else
+        {
+            _reachedTarget = false;
         }
     }
 }


### PR DESCRIPTION
I added a responseQueue for Ally and a queryQueue for GeminiService.

I also added a semaphore for the MakeQuery function in GeminiService to ensure tasks are solved sequentially to fix the gibberish reply bug when querying another prompt while the AI isn't finished yet.

I also added a SendSystemMessage function in Chat to make it easier to send (event) messages without an expected command from the ally.

I also fixed the bug / error message that the instance of a visibleForAi node that just got removed/deleted after interaction can't be accessed by checking if the current visibleForAi instance is valid in visibleForAi.cs.